### PR TITLE
Separate time validity and cancellation status consistently

### DIFF
--- a/src/components/extrajourneys/Detail.tsx
+++ b/src/components/extrajourneys/Detail.tsx
@@ -26,6 +26,7 @@ import {
   showErrorNotification,
 } from '../../reducers/notificationSlice';
 import { isJourneyActive } from '../../util/formatters';
+import { loadExtrajourneys } from '../../reducers/extrajourneysSlice';
 import api from '../../api/api';
 import { useConfig } from '../../config/ConfigContext';
 import { useAuth } from 'react-oidc-context';
@@ -82,6 +83,15 @@ export const Detail = ({ selectedOrganization }: DetailProps) => {
         selectedOrganization,
         updated,
       );
+      await dispatch(
+        loadExtrajourneys({
+          config,
+          auth,
+          codespace,
+          authority: selectedOrganization,
+          showCompletedTrips: true,
+        }),
+      );
       dispatch(
         showSuccessNotification('Lagret', 'Ekstraavgangen ble oppdatert'),
       );
@@ -124,6 +134,15 @@ export const Detail = ({ selectedOrganization }: DetailProps) => {
         selectedOrganization,
         updated,
       );
+      await dispatch(
+        loadExtrajourneys({
+          config,
+          auth,
+          codespace,
+          authority: selectedOrganization,
+          showCompletedTrips: true,
+        }),
+      );
       dispatch(
         showSuccessNotification('Kansellert', 'Ekstraavgangen ble kansellert'),
       );
@@ -148,8 +167,9 @@ export const Detail = ({ selectedOrganization }: DetailProps) => {
   if (!extrajourney) return null;
 
   const evj = extrajourney.estimatedVehicleJourney;
-  const active = isJourneyActive(evj.expiresAtEpochMs);
-  const journeyCancelled = evj.cancellation;
+  const journeyCancelled = evj.cancellation ?? false;
+  const expired = !isJourneyActive(evj.expiresAtEpochMs);
+  const editable = !expired && !journeyCancelled;
 
   return (
     <Page backButtonTitle="Oversikt" title="Ekstraavgang">
@@ -165,8 +185,8 @@ export const Detail = ({ selectedOrganization }: DetailProps) => {
               <Typography variant="h5">Turdetaljer</Typography>
               <Stack direction="row" spacing={1}>
                 <Chip
-                  label={active ? 'Aktiv' : 'Inaktiv'}
-                  color={active ? 'success' : 'error'}
+                  label={expired ? 'Utløpt' : 'Aktiv'}
+                  color={expired ? 'default' : 'success'}
                   size="small"
                 />
                 {journeyCancelled && (
@@ -274,7 +294,7 @@ export const Detail = ({ selectedOrganization }: DetailProps) => {
             </TableContainer>
           </Paper>
 
-          {active && !journeyCancelled && (
+          {editable && (
             <Stack direction="row" spacing={2}>
               <Button variant="contained" onClick={handleSave}>
                 Lagre endringer

--- a/src/components/extrajourneys/Overview.tsx
+++ b/src/components/extrajourneys/Overview.tsx
@@ -90,7 +90,12 @@ export const Overview = ({ selectedOrganization }: OverviewProps) => {
                     const calls = evj.estimatedCalls.estimatedCall;
                     const firstCall = calls[0];
                     const lastCall = calls[calls.length - 1];
-                    const active = isJourneyActive(evj.expiresAtEpochMs);
+                    const active = isJourneyActive(
+                      evj.expiresAtEpochMs,
+                      evj.cancellation,
+                    );
+                    const expired = !isJourneyActive(evj.expiresAtEpochMs);
+                    const cancelled = evj.cancellation ?? false;
 
                     return (
                       <TableRow
@@ -105,11 +110,20 @@ export const Overview = ({ selectedOrganization }: OverviewProps) => {
                         }}
                       >
                         <TableCell>
-                          <Chip
-                            label={active ? 'Aktiv' : 'Inaktiv'}
-                            color={active ? 'success' : 'error'}
-                            size="small"
-                          />
+                          <Stack spacing={0.5} alignItems="flex-start">
+                            <Chip
+                              label={expired ? 'Utløpt' : 'Aktiv'}
+                              color={expired ? 'default' : 'success'}
+                              size="small"
+                            />
+                            {cancelled && (
+                              <Chip
+                                label="Kansellert"
+                                color="error"
+                                size="small"
+                              />
+                            )}
+                          </Stack>
                         </TableCell>
                         <TableCell>{evj.publishedLineName}</TableCell>
                         <TableCell>{evj.estimatedVehicleJourneyCode}</TableCell>

--- a/src/util/formatters.test.ts
+++ b/src/util/formatters.test.ts
@@ -1,10 +1,28 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
+  isJourneyActive,
   isMessageExpired,
   formatDate,
   formatDepartureOption,
   getCancellationLabel,
 } from './formatters';
+
+describe('isJourneyActive', () => {
+  it('returns false when cancelled regardless of expiry', () => {
+    const farFuture = Date.now() + 86400000 * 30;
+    expect(isJourneyActive(farFuture, true)).toBe(false);
+  });
+
+  it('returns false when expired', () => {
+    expect(isJourneyActive(0)).toBe(false);
+  });
+
+  it('returns true when not cancelled and not expired', () => {
+    const farFuture = Date.now() + 86400000 * 30;
+    expect(isJourneyActive(farFuture)).toBe(true);
+    expect(isJourneyActive(farFuture, false)).toBe(true);
+  });
+});
 
 describe('isMessageExpired', () => {
   it('returns true when endTime is in the past', () => {

--- a/src/util/formatters.ts
+++ b/src/util/formatters.ts
@@ -2,9 +2,13 @@ import { DateFormatter, getLocalTimeZone, now } from '@internationalized/date';
 
 const TEN_MINUTES_MS = 10 * 60 * 1000;
 
-export const isJourneyActive = (expiresAtEpochMs: number): boolean =>
+export const isJourneyActive = (
+  expiresAtEpochMs: number,
+  cancellation?: boolean,
+): boolean =>
+  !cancellation &&
   expiresAtEpochMs >
-  now(getLocalTimeZone()).add({ minutes: 10 }).toDate().getTime();
+    now(getLocalTimeZone()).add({ minutes: 10 }).toDate().getTime();
 
 export const isMessageExpired = (
   endTime: string | undefined,


### PR DESCRIPTION
Show two independent status chips in both overview and detail:
- Aktiv/Utløpt: based on expiresAtEpochMs vs current time only
- Kansellert: shown when estimatedVehicleJourney.cancellation is true

Previously the detail page conflated both into one chip via isJourneyActive (which checked cancellation), while the overview separated them, causing inconsistency. Now both views use the same logic. isJourneyActive still checks the cancellation flag for controlling editability (buttons/inputs disabled).

Refetch extra journeys after save/cancel in Detail view.