### PR TITLE
Fix departure message creation failing silently

### DIFF
--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -103,7 +103,7 @@ describe('messageHelpers', () => {
   describe('createAffectsDeparture', () => {
     it('creates departure affects without stops', () => {
       const result = createAffectsDeparture(
-        { year: 2024, month: 1, day: 15 },
+        new Date(2024, 0, 15),
         'NSB:ServiceJourney:123',
       );
       expect(
@@ -118,7 +118,7 @@ describe('messageHelpers', () => {
     it('creates departure affects with stops', () => {
       const stops = [{ value: 'NSR:StopPlace:1' }];
       const result = createAffectsDepartureWithStops(
-        { year: 2024, month: 1, day: 15 },
+        new Date(2024, 0, 15),
         'NSB:ServiceJourney:123',
         stops,
       );
@@ -232,7 +232,7 @@ describe('messageHelpers', () => {
         false,
         false,
         [],
-        { year: 2024, month: 1, day: 15 },
+        new Date(2024, 0, 15),
         'NSB:ServiceJourney:1',
       );
       expect(result.vehicleJourneys.affectedVehicleJourney.route).toBeNull();
@@ -246,7 +246,7 @@ describe('messageHelpers', () => {
         false,
         true,
         stops,
-        { year: 2024, month: 1, day: 15 },
+        new Date(2024, 0, 15),
         'NSB:ServiceJourney:1',
       );
       expect(
@@ -270,9 +270,8 @@ describe('messageHelpers', () => {
   });
 
   describe('buildValidityPeriod', () => {
-    it('returns full-day period for departure type', async () => {
-      const { CalendarDate } = await import('@internationalized/date');
-      const date = new CalendarDate(2024, 6, 15);
+    it('returns full-day period for departure type', () => {
+      const date = new Date(2024, 5, 15);
       const result = buildValidityPeriod('departure', date, null, null);
       expect(result.startTime).toBeDefined();
       expect(result.endTime).toBeDefined();

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -1,4 +1,5 @@
 import {
+  fromDate,
   getLocalTimeZone,
   now,
   Time,
@@ -74,41 +75,47 @@ export const createAffectsStop = (stops: { value: string }[]) => ({
 });
 
 export const createAffectsDeparture = (
-  departureDate: any,
+  departureDate: Date,
   datedVehicleJourney: string,
-) => ({
-  vehicleJourneys: {
-    affectedVehicleJourney: {
-      framedVehicleJourneyRef: {
-        dataFrameRef: toCalendarDate(departureDate).toString(),
-        datedVehicleJourneyRef: datedVehicleJourney,
+) => {
+  const zonedDate = fromDate(departureDate, getLocalTimeZone());
+  return {
+    vehicleJourneys: {
+      affectedVehicleJourney: {
+        framedVehicleJourneyRef: {
+          dataFrameRef: toCalendarDate(zonedDate).toString(),
+          datedVehicleJourneyRef: datedVehicleJourney,
+        },
+        route: null,
       },
-      route: null,
     },
-  },
-});
+  };
+};
 
 export const createAffectsDepartureWithStops = (
-  departureDate: any,
+  departureDate: Date,
   datedVehicleJourney: string,
   stops: { value: string }[],
-) => ({
-  vehicleJourneys: {
-    affectedVehicleJourney: {
-      framedVehicleJourneyRef: {
-        dataFrameRef: toCalendarDate(departureDate).toString(),
-        datedVehicleJourneyRef: datedVehicleJourney,
-      },
-      route: {
-        stopPoints: {
-          affectedStopPoint: stops.map((s) => ({
-            stopPointRef: s.value,
-          })),
+) => {
+  const zonedDate = fromDate(departureDate, getLocalTimeZone());
+  return {
+    vehicleJourneys: {
+      affectedVehicleJourney: {
+        framedVehicleJourneyRef: {
+          dataFrameRef: toCalendarDate(zonedDate).toString(),
+          datedVehicleJourneyRef: datedVehicleJourney,
+        },
+        route: {
+          stopPoints: {
+            affectedStopPoint: stops.map((s) => ({
+              stopPointRef: s.value,
+            })),
+          },
         },
       },
     },
-  },
-});
+  };
+};
 
 export const buildAffects = (
   type: AffectType | undefined,
@@ -146,12 +153,15 @@ export const buildValidityPeriod = (
   to: any,
 ) => {
   if (type === 'departure') {
+    const calendarDate = toCalendarDate(
+      fromDate(departureDate, getLocalTimeZone()),
+    );
     const start = toZoned(
-      toCalendarDateTime(departureDate, new Time(0, 0, 0, 0)),
+      toCalendarDateTime(calendarDate, new Time(0, 0, 0, 0)),
       getLocalTimeZone(),
     );
     const end = toZoned(
-      toCalendarDateTime(departureDate, new Time(23, 59, 59, 999)),
+      toCalendarDateTime(calendarDate, new Time(23, 59, 59, 999)),
       getLocalTimeZone(),
     );
     return {


### PR DESCRIPTION
## Summary
- Creating a deviation message for a specific departure failed silently with "Kunne ikke opprette melding" — no network request was made
- Root cause: MUI DatePicker produces a native JS `Date`, but `messageHelpers.ts` passed it directly to `@internationalized/date` functions (`toCalendarDate`, `toCalendarDateTime`) which don't accept native `Date` objects, causing an exception caught by the generic error handler
- Fix: use `fromDate()` from `@internationalized/date` to convert the native `Date` to a `ZonedDateTime` before calling these functions

## Test plan
- [x] All 35 existing messageHelpers tests pass
- [x] TypeScript compiles cleanly
- [ ] Manually verify creating a deviation message for a departure works end-to-end