### PR TITLE
Update TypeScript v5 -> v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "lint-staged": "17.0.7",
         "npm-run-all2": "9.0.2",
         "prettier": "3.8.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "7.3.5",
         "vite-plugin-svgr": "4.5.0",
         "vite-tsconfig-paths": "6.1.1",
@@ -5188,9 +5188,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint-staged": "17.0.7",
     "npm-run-all2": "9.0.2",
     "prettier": "3.8.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "7.3.5",
     "vite-plugin-svgr": "4.5.0",
     "vite-tsconfig-paths": "6.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
Major upgrade of **TypeScript** `5.9.3 → 6.0.3` (Renovate #995).

**Risk: high** (compiler major) — but the only breakage was a deprecated compiler option.

## Change required
TS6 hard-errors on `moduleResolution: "node"` (the legacy `node10` algorithm), which will be removed in TS7. Migrated `tsconfig.json` to **`moduleResolution: "bundler"`** — the recommended setting for Vite projects, since Vite (not `tsc`) performs module resolution at build time. `module` stays `esnext`, which is compatible.

No source code changes were needed — no new type errors surfaced.

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `vite build` succeeds (`build` = `tsc && vite build`)
- ✅ All 116 tests pass

Replaces Renovate #995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)