### PR TITLE
Update GitHub artifact actions (upload v6->v7, download v7->v8)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           REACT_APP_VERSION: ${{ github.sha }}
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           path: |
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
           path: build


### PR DESCRIPTION
## Summary
Major upgrade of the GitHub artifact actions (Renovate #987), in `.github/workflows/firebase-hosting-merge.yml`:
- `actions/upload-artifact` `v6.0.0 → v7.0.1`
- `actions/download-artifact` `v7.0.0 → v8.0.1` (×3 — dev/staging/prod deploy jobs)

**Risk: medium** — touches the production deploy pipeline.

`download-artifact` v8 migrated to ESM and no longer auto-unzips non-zip downloads (it checks `Content-Type` first, with a new `skip-decompress` opt-out). Our workflow uploads a single `build/` directory artifact and downloads it by name in each deploy job — a zipped directory artifact, so this behavior change doesn't apply. `upload@v7` + `download@v8` are the mutually-compatible pairing.

## Verification
- ✅ All 4 action refs updated; no stale refs remain
- ⚙️ The actual run is validated by CI on this PR (can't execute Actions locally)

Replaces Renovate #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)